### PR TITLE
momentum and attempt at turn around fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+*.xcodeproj

--- a/verdeciel/CorePlayer.swift
+++ b/verdeciel/CorePlayer.swift
@@ -33,6 +33,9 @@ class CorePlayer : SCNNode
 	
 	var isLocked:Bool = false
 	var isConnectedToRadar = false
+    
+    var accelX:Float = 0;
+    var accelY:Float = 0;
 	
 	override init()
 	{
@@ -137,6 +140,20 @@ class CorePlayer : SCNNode
 	override func fixedUpdate()
 	{
 		flickerAlert()
+        
+        if !isLocked {
+            player.eulerAngles.x += accelX
+            player.eulerAngles.y += accelY
+
+            //should keep the values within 2pi rads
+            player.eulerAngles.x = Float(Double(player.eulerAngles.x) % (2 * M_PI))
+            player.eulerAngles.y = Float(Double(player.eulerAngles.y) % (2 * M_PI))
+
+            //dampening
+            // closer to 1 for more 'momentum'
+            accelX *= 0.75
+            accelY *= 0.75
+        }
 		
 		// Check is starmap is still connected
 		if port.origin == nil && isConnectedToRadar == true {
@@ -153,9 +170,26 @@ class CorePlayer : SCNNode
 	
 	func lookAt(position:SCNVector3 = SCNVector3(0,0,0),deg:CGFloat)
 	{
-		player.eulerAngles.y = Float(degToRad(radToDeg(CGFloat(player.eulerAngles.y)) % 360))
-		ui.eulerAngles.y = Float(degToRad(radToDeg(CGFloat(ui.eulerAngles.y)) % 360))
-		
+        player.eulerAngles.y = Float(Double(player.eulerAngles.y) % (2 * M_PI))
+        //if degrees is less than zero. convert it to 0-360 (rather than -360 - 0)
+        if player.eulerAngles.y < 0 {
+            player.eulerAngles.y = Float(2 * M_PI) + player.eulerAngles.y
+        }
+        //if it's more than 180, subtract 360 degrees (this will put as between -180 and 180 degrees
+        if player.eulerAngles.y > Float(M_PI) {
+            player.eulerAngles.y -= Float(2 * M_PI)
+        }
+        
+        ui.eulerAngles.y = Float(Double(player.eulerAngles.y) % (2 * M_PI))
+        //if degrees is less than zero. convert it to 0-360 (rather than -360 - 0)
+        if ui.eulerAngles.y < 0 {
+            ui.eulerAngles.y = Float(2 * M_PI) + ui.eulerAngles.y
+        }
+        //if it's more than 180, subtract 360 degrees (this will put as between -180 and 180 degrees
+        if ui.eulerAngles.y > Float(M_PI) {
+            ui.eulerAngles.y -= Float(2 * M_PI)
+        }
+        
 		player.isLocked = true
 		
 		SCNTransaction.begin()

--- a/verdeciel/CorePlayer.swift
+++ b/verdeciel/CorePlayer.swift
@@ -153,6 +153,12 @@ class CorePlayer : SCNNode
             // closer to 1 for more 'momentum'
             accelX *= 0.75
             accelY *= 0.75
+            if abs(accelX) < 0.005 {
+                accelX = 0; //if it gets too small just drop to zero
+            }
+            if abs(accelY) < 0.005 {
+                accelY = 0; //if it gets too small just drop to zero
+            }
         }
 		
 		// Check is starmap is still connected

--- a/verdeciel/CoreUI.swift
+++ b/verdeciel/CoreUI.swift
@@ -29,6 +29,9 @@ class CoreUI: SCNNode
 	
 	let textSize:Float = 0.025
 	let visorDepth = -1.3
+    
+    var accelX:Float = 0;
+    var accelY:Float = 0;
 	
 	override init()
 	{
@@ -97,6 +100,16 @@ class CoreUI: SCNNode
 	
 	override func fixedUpdate()
 	{
+        if !player.isLocked {
+            ui.eulerAngles.x += accelX;
+            ui.eulerAngles.y += accelY;
+            
+            //dampening
+            // closer to 1 for more 'momentum'
+            accelX *= 0.75;
+            accelY *= 0.75;
+        }
+        
 		if canAlign == true {
 			if (eulerAngles.y - player.eulerAngles.y) > 0.0001 && eulerAngles.y > player.eulerAngles.y {
 				eulerAngles.y -= (eulerAngles.y - player.eulerAngles.y) * 0.1

--- a/verdeciel/CoreUI.swift
+++ b/verdeciel/CoreUI.swift
@@ -112,6 +112,12 @@ class CoreUI: SCNNode
             // closer to 1 for more 'momentum'
             accelX *= 0.75;
             accelY *= 0.75;
+            if abs(accelX) < 0.005 {
+                accelX = 0; //if it gets too small just drop to zero
+            }
+            if abs(accelY) < 0.005 {
+                accelY = 0; //if it gets too small just drop to zero
+            }
         }
         
 		if canAlign == true {

--- a/verdeciel/CoreUI.swift
+++ b/verdeciel/CoreUI.swift
@@ -104,6 +104,10 @@ class CoreUI: SCNNode
             ui.eulerAngles.x += accelX;
             ui.eulerAngles.y += accelY;
             
+            //keeps us within 2pi
+            ui.eulerAngles.x = Float(Double(ui.eulerAngles.x) % (2 * M_PI))
+            ui.eulerAngles.y = Float(Double(ui.eulerAngles.y) % (2 * M_PI))
+            
             //dampening
             // closer to 1 for more 'momentum'
             accelX *= 0.75;

--- a/verdeciel/GameViewController.swift
+++ b/verdeciel/GameViewController.swift
@@ -137,12 +137,16 @@ class GameViewController: UIViewController, SCNSceneRendererDelegate
 		
 		touchOrigin = touchPosition
 
-		player.eulerAngles.x += Float(degToRad(dragY/4))
-		player.eulerAngles.y += Float(degToRad(dragX/4))
+//		player.eulerAngles.x += Float(degToRad(dragY/4))
+//		player.eulerAngles.y += Float(degToRad(dragX/4))
+        player.accelY += Float(degToRad(dragX/4))
+        player.accelX += Float(degToRad(dragY/4))
 		
-		ui.eulerAngles.x += Float(degToRad(dragY/4)) * 0.975
-		ui.eulerAngles.y += Float(degToRad(dragX/4)) * 0.95
-		
+//		ui.eulerAngles.x += Float(degToRad(dragY/4)) * 0.975
+//		ui.eulerAngles.y += Float(degToRad(dragX/4)) * 0.95
+		ui.accelX += Float(degToRad(dragY/4)) * 0.975
+        ui.accelY += Float(degToRad(dragX/4)) * 0.95
+        
 		ui.updatePort()
 	}
 	


### PR DESCRIPTION
This adds an "acceleration" which basically is a value that keeps getting added to the angle until the acceleration is slowed down. this is applied to CorePlayer and CoreUI

Also attempt at fixing this turnaround bug where the transition for the lookat function would sometimes go the long way around. Still might need to test the other occurrences of the lookat function to ensure it's working properly (I _might_ have the correct math on it)